### PR TITLE
feature: option to limit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ $PodcastCrawler = new PodcastCrawler($provider);
 $PodcastCrawler->get('nerdcast');
 //=> Returns an array with search result (result count and a list with podcasts)
 
+$PodcastCrawler->limit(1)->get('a');
+//=> Returns an array with 1 (one) item. Result count is also included.
+
 $PodcastCrawler->find(381816509);
-// Returns an array with the podcast's detail and episodes with its mp3 files.
+//=> Returns an array with the podcast's detail and episodes with its mp3 files.
 ```
 
 ### API

--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ $ composer require podcastcrawler/podcastcrawler
 require 'vendor/autoload.php';
 
 use PodcastCrawler\PodcastCrawler;
+use PodcastCrawler\Provider\Itunes;
 
-$PodcastCrawler = new PodcastCrawler();
+$provider = new Itunes();
+$PodcastCrawler = new PodcastCrawler($provider);
 
-$searchByTerm = $PodcastCrawler->get('nerdcast');
-var_dump($searchByTerm); // Returns an array with search result (result count and a list with podcasts)
+$PodcastCrawler->get('nerdcast');
+//=> Returns an array with search result (result count and a list with podcasts)
 
-$getFeed = $PodcastCrawler->find(381816509);
-var_dump($getFeed); // Returns an array with the podcast's detail and episodes with its mp3 files.
+$PodcastCrawler->find(381816509);
+// Returns an array with the podcast's detail and episodes with its mp3 files.
 ```
 
 ### API

--- a/src/PodcastCrawler.php
+++ b/src/PodcastCrawler.php
@@ -14,7 +14,7 @@ use SimpleXMLElement;
 use Exception;
 
 /**
- * Class Podcastcrawler\Podcastcrawler enables the search for podcasts to get details and mp3 files through many API
+ * Class Podcastcrawler\Podcastcrawler enables the search for podcasts to get details and mp3 files through many APIs
  *
  * @version   v1.0.0
  * @link      https://github.com/podcastcrawler/podcastcrawler
@@ -78,12 +78,10 @@ class PodcastCrawler
             throw new Exception("Request to Itunes API failed", $request->getStatusCode());
         }
 
-        $output = [
+        return [
             'search'      => $response,
             'status_code' => $request->getStatusCode(),
         ];
-
-        return $output;
     }
 
     /**
@@ -106,15 +104,20 @@ class PodcastCrawler
                 $feed              = new SimpleXMLElement($response_repaired, LIBXML_NOCDATA, false);
             }
 
-            $output = $this->provider->buildFeed($feed);
+            return $this->provider->buildFeed($feed);
         } catch (Exception $except) {
-            $output = [
+            return [
                 'status_code' => $except->getCode(),
                 'message'     => $except->getMessage()
             ];
         }
+    }
 
-        return $output;
+    public function limit($limit) {
+        $this->provider->setLimit($limit);
+        $this->provider->setDefaultQuery();
+
+        return $this;
     }
 
     /**
@@ -133,11 +136,9 @@ class PodcastCrawler
             throw new Exception("Request to RSS failed", $request->getStatusCode());
         }
 
-        $output = [
+        return [
             'feed'        => $output,
             'status_code' => $request->getStatusCode(),
         ];
-
-        return $output;
     }
 }

--- a/src/Provider/DigitalPodcast.php
+++ b/src/Provider/DigitalPodcast.php
@@ -41,18 +41,18 @@ class DigitalPodcast extends AbstractProvider implements ProviderInterface
     const SEARCH_URL = "http://api.digitalpodcast.com/v2r/search";
 
     /**
-     * The number of results to return
-     *
-     * @var int
-     */
-    const RESULTS = 15;
-
-    /**
      * Specifies the kind of format the podcast search service produces
      *
      * @var string
      */
     const FORMAT = "rss";
+
+    /**
+     * The number of results to return
+     *
+     * @var int
+     */
+    private $limit = 15;
 
     /**
      * Array with default query string values to implement in base url
@@ -66,9 +66,35 @@ class DigitalPodcast extends AbstractProvider implements ProviderInterface
      */
     public function __construct()
     {
+        $this->setDefaultQuery();
+    }
+
+    /**
+     * Returns the limit for search
+     *
+     * @return int
+     */
+    public function getLimit() {
+        return $this->limit;
+    }
+
+    /**
+     * Set the limit for search
+     *
+     * @param int $limit The limit
+     */
+    public function setLimit($limit) {
+        // `-1` being used here because the API returns 3 items when `results=2`.
+        $this->limit = ((int) $limit - 1);
+    }
+
+    /**
+     * Set default URL query for search
+     */
+    public function setDefaultQuery() {
         $this->defaultQuery = http_build_query([
+            'results' => $this->limit,
             'appid'   => self::APP_ID,
-            'results' => self::RESULTS,
             'format'  => self::FORMAT
         ]);
     }

--- a/src/Provider/Itunes.php
+++ b/src/Provider/Itunes.php
@@ -38,13 +38,6 @@ class Itunes extends AbstractProvider implements ProviderInterface
     const LOOKUP_URL = "https://itunes.apple.com/lookup";
 
     /**
-     * The number of search results you want the iTunes Store to return
-     *
-     * @var int
-     */
-    const LIMIT = 15;
-
-    /**
      * The type of results you want returned, relative to the specified media type
      *
      * @var string
@@ -59,6 +52,13 @@ class Itunes extends AbstractProvider implements ProviderInterface
     const MEDIA = "podcast";
 
     /**
+     * The number of search results you want the iTunes Store to return
+     *
+     * @var int
+     */
+    private $limit = 15;
+
+    /**
      * Array with default query string values to implement in selected base url
      *
      * @var string
@@ -70,8 +70,33 @@ class Itunes extends AbstractProvider implements ProviderInterface
      */
     public function __construct()
     {
+        $this->setDefaultQuery();
+    }
+
+    /**
+     * Returns the limit for search
+     *
+     * @return int
+     */
+    public function getLimit() {
+        return $this->limit;
+    }
+
+    /**
+     * Set the limit for search
+     *
+     * @param int $limit The limit
+     */
+    public function setLimit($limit) {
+        $this->limit = (int) $limit;
+    }
+
+    /**
+     * Set default URL query for search
+     */
+    public function setDefaultQuery() {
         $this->defaultQuery = http_build_query([
-            'limit'     => self::LIMIT,
+            'limit'     => $this->limit,
             'entity'    => self::ENTITY,
             'media'     => self::MEDIA
         ]);

--- a/tests/PodcastCrawlerTest.php
+++ b/tests/PodcastCrawlerTest.php
@@ -32,6 +32,21 @@ class PodcastCrawlerTest extends Base
     }
 
     /**
+     * Test to validate the return of the search sought by the term with a specified limit
+     */
+    public function testGetWithLimit()
+    {
+        $limit  = 2;
+        $search = 'a';
+
+        $result = $this->instance->limit($limit)->get($search);
+
+        $this->assertInternalType('array', $result);
+        $this->assertEquals($limit, $result['result_count']);
+        $this->assertEquals($limit, count($result));
+    }
+
+    /**
      * Test to validate the return of the feed sought by RSS URL
      */
     public function testFind()

--- a/tests/Provider/DigitalPodcastProviderTest.php
+++ b/tests/Provider/DigitalPodcastProviderTest.php
@@ -27,6 +27,14 @@ class DigitalPodcastProviderTest extends Base
         $this->instance = new PodcastCrawler($this->providerInstance);
     }
 
+    public function testLimit() {
+        $limit = 14;
+
+        $this->providerInstance->setLimit($limit);
+
+        $this->assertEquals($limit, $this->providerInstance->getLimit() + 1);
+    }
+
     public function testDigitalPodcastBuild()
     {
         $result = $this->instance->get(self::TERM);

--- a/tests/Provider/ItunesProviderTest.php
+++ b/tests/Provider/ItunesProviderTest.php
@@ -27,6 +27,14 @@ class ItunesProviderTest extends Base
         $this->instance = new PodcastCrawler($this->providerInstance);
     }
 
+    public function testLimit() {
+        $limit = 10;
+
+        $this->providerInstance->setLimit($limit);
+
+        $this->assertEquals($limit, $this->providerInstance->getLimit());
+    }
+
     public function testItunesBuild()
     {
         $result = $this->instance->get(self::TERM);


### PR DESCRIPTION
Now we can limit the results. 👌 

```php
$PodcastCrawler->limit(1)->get('term');
//=> Returns an array with 1 item.

$PodcastCrawler->limit(2)->get('term');
//=> Returns an array with 2 items.
```

Ok, you got it.

I've also updated the docs. Currently we need to set a provider to search a term and it wasn't documented. 📝 

--
Probably the tests will fail because of the [Digital Podcasts' API](api.digitalpodcast.com/v2r/search?keywords=nerd+cast&results=15&appid=podcastsearchdemo&format=rss). Actually I think it's dead. 😂 

// @dorianneto 